### PR TITLE
Fix hyphenated names overflowing (#1667)

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1282,6 +1282,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	display: block;
 	line-height: 1.6;
 	padding: 0 16px;
+	white-space: nowrap;
 }
 
 #chat .user-mode::before {


### PR DESCRIPTION
This is just a quick and dirty fix for the issue described over at #1667, which is hyphenated names tend to overflow on to the next line.